### PR TITLE
Backend: GLAD JSON + Feature selection

### DIFF
--- a/backend/src/attribution/network_interface.ts
+++ b/backend/src/attribution/network_interface.ts
@@ -35,4 +35,5 @@ export function FromClientAttribution_isValid( request: any ): boolean {
  */
 export interface ToClientAttribution {
   sameAuthorConfidence: number;
+  statistics: any;
 }


### PR DESCRIPTION
JSON output from GLAD is now verbatim passed through to the frontend.

`sameAuthorConfidence` field is still the same.
New field `statistics`, which is the GLAD JSON output verbatim

Feature combo selection (1 or 4) also works through the frontend.